### PR TITLE
Fix SYNC_WITH_TANK

### DIFF
--- a/server/Game/entities/entity.js
+++ b/server/Game/entities/entity.js
@@ -624,6 +624,7 @@ class Entity extends EventEmitter {
             })
             this.settings.shakeProperties = info;
         }
+        this.syncWithTank = set.SYNC_WITH_TANK ?? false
         if (set.mockup != null) {
             this.mockup = set.mockup;
         }
@@ -826,7 +827,8 @@ class Entity extends EventEmitter {
             offset: boundData.offset,
             sizeFactor: boundData.size,
             twiggle: forceTwiggle.includes(this.facingType) || this.eastereggs.braindamage || 
-                    this.settings.connectChildrenOnCamera || (this.facingType === "locksFacing" && this.control.alt),
+                    this.settings.connectChildrenOnCamera || (this.facingType === "locksFacing" && this.control.alt) ||
+                    this.syncWithTank,
             layer: layerValue,
             color: this.color.compiled,
             borderless: this.borderless,


### PR DESCRIPTION
Property that a few tanks used before it disappeared for some reason. All it does is make the client use the entity's rotation when playing as a tank instead of the target when it's true. 
true -> Listen to the server for rotation
false -> Default behavior